### PR TITLE
Clan page ui and functionality

### DIFF
--- a/sea-of-code/src/api/users.ts
+++ b/sea-of-code/src/api/users.ts
@@ -1,4 +1,4 @@
-import { doc, getDoc, serverTimestamp, setDoc } from 'firebase/firestore';
+import { doc, getDoc, serverTimestamp, setDoc, updateDoc } from 'firebase/firestore';
 import type { FirestoreUser, FirestoreUserCreate } from '../types/types';
 import { db } from '../firebase/config';
 import type { User } from 'firebase/auth';
@@ -30,6 +30,7 @@ export const getOrCreateUser = async (user: User): Promise<FirestoreUser> => {
       clan: null,
       streak: 1,
       lastLoginDate: serverTimestamp(),
+      clanJoinedAt: null,
     },
   };
 
@@ -53,4 +54,25 @@ export const getDataFromUser = async (userId: string) => {
     console.error('Error fetching user data:', error);
     throw error;
   }
+};
+
+export const joinClan = async (userId: string, clanKey: string, isChange = false) => {
+  const ref = doc(db, 'users', userId);
+  const updates: Record<string, unknown> = {
+    'stats.clan': clanKey,
+    'stats.clanJoinedAt': serverTimestamp(),
+  };
+
+  if (isChange) {
+    updates['stats.victories'] = 0;
+    updates['stats.defeats'] = 0;
+    updates['stats.battles'] = 0;
+    updates['stats.fleet_storm'] = 0;
+    updates['stats.miles_at_sea'] = 0;
+    updates['stats.sea_wolf'] = 0;
+    updates['stats.sniper'] = 0;
+    updates['stats.to_rank'] = 0;
+  }
+
+  await updateDoc(ref, updates);
 };

--- a/sea-of-code/src/api/users.ts
+++ b/sea-of-code/src/api/users.ts
@@ -31,6 +31,11 @@ export const getOrCreateUser = async (user: User): Promise<FirestoreUser> => {
       streak: 1,
       lastLoginDate: serverTimestamp(),
       clanJoinedAt: null,
+      clanStats: {
+        victories: 0,
+        defeats: 0,
+        battles: 0,
+      },
     },
   };
 
@@ -64,14 +69,9 @@ export const joinClan = async (userId: string, clanKey: string, isChange = false
   };
 
   if (isChange) {
-    updates['stats.victories'] = 0;
-    updates['stats.defeats'] = 0;
-    updates['stats.battles'] = 0;
-    updates['stats.fleet_storm'] = 0;
-    updates['stats.miles_at_sea'] = 0;
-    updates['stats.sea_wolf'] = 0;
-    updates['stats.sniper'] = 0;
-    updates['stats.to_rank'] = 0;
+    updates['stats.clanStats.victories'] = 0;
+    updates['stats.clanStats.defeats'] = 0;
+    updates['stats.clanStats.battles'] = 0;
   }
 
   await updateDoc(ref, updates);

--- a/sea-of-code/src/constants/images.ts
+++ b/sea-of-code/src/constants/images.ts
@@ -38,6 +38,8 @@ export const clans = {
     tagline: 'Masters of clean architecture and elegant solutions',
     description:
       'Born from the wreckage of a thousand failed deploys, the Code Clan believes that beauty in structure is the highest form of power. They sail not to destroy — they sail to refactor the seas themselves.',
+    color: '#22c55e',
+    colorMuted: 'rgba(34, 197, 94, 0.12)',
   },
   brotherhood_bugs: {
     name: 'The Brotherhood of Bugs',
@@ -45,6 +47,8 @@ export const clans = {
     tagline: 'We hunt what others fear to face',
     description:
       'Where others see errors, the Brotherhood sees opportunity. This rogue fraction embraces chaos, turning every crash and edge case into a weapon against the unprepared.',
+    color: '#3b82f6',
+    colorMuted: 'rgba(59, 130, 246, 0.12)',
   },
   league_logic: {
     name: 'League of Logic',
@@ -52,5 +56,7 @@ export const clans = {
     tagline: 'Reason and precision guide every battle',
     description:
       'Cold, calculated, and relentless — the League of Logic does not fight on instinct. Every move is a theorem, every battle a proof, and defeat is simply an unsolved equation.',
+    color: '#eab308',
+    colorMuted: 'rgba(234, 179, 8, 0.12)',
   },
 };

--- a/sea-of-code/src/constants/images.ts
+++ b/sea-of-code/src/constants/images.ts
@@ -44,7 +44,7 @@ export const clans = {
     image: './profile-images/brotherhood_bugs.png',
     tagline: 'We hunt what others fear to face',
     description:
-      'Where others see errors, the Brotherhood sees opportunity. This rogue faction embraces chaos, turning every crash and edge case into a weapon against the unprepared.',
+      'Where others see errors, the Brotherhood sees opportunity. This rogue fraction embraces chaos, turning every crash and edge case into a weapon against the unprepared.',
   },
   league_logic: {
     name: 'League of Logic',

--- a/sea-of-code/src/constants/images.ts
+++ b/sea-of-code/src/constants/images.ts
@@ -34,14 +34,23 @@ export const ranks = {
 export const clans = {
   сode_сlan: {
     name: 'The Code Clan',
-    image: './profile-images/clan-1.png',
+    image: './profile-images/сode_сlan.png',
+    tagline: 'Masters of clean architecture and elegant solutions',
+    description:
+      'Born from the wreckage of a thousand failed deploys, the Code Clan believes that beauty in structure is the highest form of power. They sail not to destroy — they sail to refactor the seas themselves.',
   },
   brotherhood_bugs: {
     name: 'The Brotherhood of Bugs',
     image: './profile-images/brotherhood_bugs.png',
+    tagline: 'We hunt what others fear to face',
+    description:
+      'Where others see errors, the Brotherhood sees opportunity. This rogue faction embraces chaos, turning every crash and edge case into a weapon against the unprepared.',
   },
   league_logic: {
     name: 'League of Logic',
     image: './profile-images/league_logic.png',
+    tagline: 'Reason and precision guide every battle',
+    description:
+      'Cold, calculated, and relentless — the League of Logic does not fight on instinct. Every move is a theorem, every battle a proof, and defeat is simply an unsolved equation.',
   },
 };

--- a/sea-of-code/src/pages/clans/clans.css
+++ b/sea-of-code/src/pages/clans/clans.css
@@ -21,12 +21,56 @@
 }
 
 .clan-card--active {
-  animation: clan-select 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) both;
   box-shadow:
     0 0 0 2px var(--clan-color, #6366f1),
     0 0 30px color-mix(in srgb, var(--clan-color, #6366f1) 40%, transparent);
 }
 
+.clan-card--just-joined {
+  animation: clan-select 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
 .animate-fade-in-up {
   animation: fade-in-up 0.3s ease-out both;
+}
+
+@keyframes backdrop-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes modal-bounce-in {
+  0%   { opacity: 0; transform: scale(0.25) rotate(-18deg) translateY(-30px); }
+  55%  { opacity: 1; transform: scale(1.12) rotate(4deg) translateY(0); }
+  75%  { transform: scale(0.93) rotate(-2deg); }
+  90%  { transform: scale(1.04) rotate(1deg); }
+  100% { opacity: 1; transform: scale(1) rotate(0deg); }
+}
+
+@keyframes img-pop-spin {
+  0%   { opacity: 0; transform: scale(0) rotate(-200deg); }
+  60%  { opacity: 1; transform: scale(1.35) rotate(15deg); }
+  80%  { transform: scale(0.88) rotate(-6deg); }
+  100% { opacity: 1; transform: scale(1) rotate(0deg); }
+}
+
+@keyframes text-slide-up {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.modal-backdrop-animated {
+  animation: backdrop-fade-in 0.2s ease forwards;
+}
+
+.modal-bounce-in {
+  animation: modal-bounce-in 0.55s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+.modal-img-pop {
+  animation: img-pop-spin 0.65s cubic-bezier(0.34, 1.56, 0.64, 1) 0.05s both;
+}
+
+.modal-text-in {
+  animation: text-slide-up 0.35s ease 0.3s both;
 }

--- a/sea-of-code/src/pages/clans/clans.css
+++ b/sea-of-code/src/pages/clans/clans.css
@@ -1,0 +1,32 @@
+@keyframes clan-select {
+  0%   { transform: scale(1); }
+  45%  { transform: scale(1.06); }
+  70%  { transform: scale(1.01); }
+  100% { transform: scale(1.02); }
+}
+
+@keyframes fade-in-up {
+  from { opacity: 0; transform: translateY(18px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.clan-card {
+  transition: box-shadow 0.25s ease, opacity 0.2s ease;
+}
+
+.clan-card:not(.clan-card--active):hover {
+  box-shadow:
+    0 0 0 1.5px var(--clan-color, #6366f1),
+    0 0 18px color-mix(in srgb, var(--clan-color, #6366f1) 28%, transparent);
+}
+
+.clan-card--active {
+  animation: clan-select 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  box-shadow:
+    0 0 0 2px var(--clan-color, #6366f1),
+    0 0 30px color-mix(in srgb, var(--clan-color, #6366f1) 40%, transparent);
+}
+
+.animate-fade-in-up {
+  animation: fade-in-up 0.3s ease-out both;
+}

--- a/sea-of-code/src/pages/clans/clans.tsx
+++ b/sea-of-code/src/pages/clans/clans.tsx
@@ -8,6 +8,7 @@ import Message from '../../components/ui/Message';
 import { db } from '../../firebase/config';
 import ClanCard from './components/ClanCard';
 import ClanDetailView from './components/ClanDetailView';
+import ChangeClanModal from './components/ChangeClanModal';
 import type { ClanKey, ClanStatsMap } from '../../types/clans.type';
 import './clans.css';
 
@@ -15,6 +16,7 @@ const Clans = () => {
   const { user, userData, loading } = useAuth();
   const [actionLoading, setActionLoading] = useState(false);
   const [error, setError] = useState('');
+  const [confirmClan, setConfirmClan] = useState<ClanKey | null>(null);
   const [detailsClan, setDetailsClan] = useState<ClanKey | null>(null);
   const [clanStats, setClanStats] = useState<ClanStatsMap>({});
 
@@ -54,10 +56,24 @@ const Clans = () => {
 
   const handleJoin = async (clanKey: ClanKey) => {
     if (!user) return;
+    if (currentClanKey) {
+      setConfirmClan(clanKey);
+      return;
+    }
+    await doJoin(clanKey, false);
+  };
+
+  const handleConfirmChange = async () => {
+    if (!confirmClan) return;
+    setConfirmClan(null);
+    await doJoin(confirmClan, true);
+  };
+
+  const doJoin = async (clanKey: ClanKey, isChange: boolean) => {
+    if (!user) return;
     setActionLoading(true);
     setError('');
     try {
-      const isChange = !!currentClanKey;
       await joinClan(user.uid, clanKey, isChange);
     } catch {
       setError('Failed to join clan. Please try again.');
@@ -77,6 +93,14 @@ const Clans = () => {
   }
 
   return (
+    <>
+      {confirmClan && (
+        <ChangeClanModal
+          onConfirm={handleConfirmChange}
+          onCancel={() => setConfirmClan(null)}
+          disabled={actionLoading}
+        />
+      )}
       <section className='doodle doodle-border mx-auto my-4 flex w-full flex-col items-center gap-6 p-6 sm:w-[95%] md:w-[90%] lg:w-[85%] xl:w-240'>
         <div className='flex flex-col items-center gap-2'>
           <h1 className='text-3xl font-bold'>Choose Your Clan</h1>
@@ -106,7 +130,8 @@ const Clans = () => {
         </div>
 
       </section>
-    );
+    </>
+  );
 };
 
 export default Clans;

--- a/sea-of-code/src/pages/clans/clans.tsx
+++ b/sea-of-code/src/pages/clans/clans.tsx
@@ -1,5 +1,193 @@
+import { useState } from 'react';
+import { useAuth } from '../../firebase/useAuth';
+import { joinClan } from '../../api/users';
+import { clans } from '../../constants/images';
+import Button from '../../components/ui/Button';
+import Loading from '../../components/ui/loading';
+import Message from '../../components/ui/Message';
+
+type ClanKey = keyof typeof clans;
+
+const ClanCard = ({
+  clanKey,
+  isCurrent,
+  onJoin,
+  onDetails,
+  disabled,
+}: {
+  clanKey: ClanKey;
+  isCurrent: boolean;
+  onJoin: (key: ClanKey) => void;
+  onDetails: (key: ClanKey) => void;
+  disabled: boolean;
+}) => {
+  const clan = clans[clanKey];
+  return (
+    <div
+      className={`doodle-border flex flex-col items-center gap-3 p-4 transition-all ${isCurrent ? 'bg-indigo-100 dark:bg-indigo-900/30 scale-[1.02] shadow-lg' : 'opacity-80 hover:opacity-100'}`}
+    >
+      <img
+        src={clan.image}
+        alt={clan.name}
+        className={`h-24 w-24 object-contain transition-all ${isCurrent ? 'scale-110' : ''}`}
+      />
+      <h2 className='text-center text-lg font-semibold'>{clan.name}</h2>
+      {isCurrent && (
+        <span className='text-xs font-semibold text-indigo-500 uppercase tracking-widest'>
+          Your clan
+        </span>
+      )}
+      <p className='text-center text-sm opacity-70'>{clan.tagline}</p>
+
+      <div className='mt-auto flex w-full flex-col gap-2'>
+        <Button variant='secondary' onClick={() => onDetails(clanKey)} className='w-full'>
+          About
+        </Button>
+        {!isCurrent && (
+          <Button onClick={() => onJoin(clanKey)} disabled={disabled} variant='primary' className='w-full'>
+            Join
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const ClanDetailView = ({
+  clanKey,
+  onBack,
+}: {
+  clanKey: ClanKey;
+  onBack: () => void;
+}) => {
+  const clan = clans[clanKey];
+  return (
+    <section className='doodle-border mx-auto my-4 flex w-full flex-col items-center gap-6 p-6 sm:w-[95%] md:w-[90%] lg:w-[85%] xl:w-240'>
+      <div className='flex w-full'>
+        <Button variant='secondary' onClick={onBack} className='w-28'>
+          ← Back
+        </Button>
+      </div>
+
+      <div className='doodle-border flex w-full flex-col items-center gap-4 p-6 sm:flex-row sm:gap-8'>
+        <img src={clan.image} alt={clan.name} className='h-32 w-32 object-contain' />
+        <div className='flex flex-col gap-2'>
+          <h2 className='text-2xl font-bold'>{clan.name}</h2>
+          <p className='opacity-70 italic'>{clan.tagline}</p>
+          <p className='text-sm opacity-50 leading-relaxed'>{clan.description}</p>
+        </div>
+      </div>
+    </section>
+  );
+};
+
 const Clans = () => {
-  return <h1>Clans</h1>;
+  const { user, userData, loading } = useAuth();
+  const [isChanging, setIsChanging] = useState(false);
+  const [actionLoading, setActionLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [detailsClan, setDetailsClan] = useState<ClanKey | null>(null);
+  const [stayOnGrid, setStayOnGrid] = useState(false);
+
+  if (loading) return <Loading />;
+  if (!user || !userData) return <Message variant='error' message='Please log in' />;
+
+  const currentClanKey = userData.stats.clan as ClanKey | null;
+
+  const handleJoin = async (clanKey: ClanKey) => {
+    if (!user) return;
+    setActionLoading(true);
+    setError('');
+    try {
+      const isChange = !!currentClanKey && isChanging;
+      await joinClan(user.uid, clanKey, isChange);
+      setIsChanging(false);
+      setStayOnGrid(true);
+    } catch {
+      setError('Failed to join clan. Please try again.');
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const showSelection = !currentClanKey || isChanging || stayOnGrid;
+
+  if (detailsClan) {
+    return <ClanDetailView clanKey={detailsClan} onBack={() => setDetailsClan(null)} />;
+  }
+
+  if (showSelection) {
+    return (
+      <section className='doodle-border mx-auto my-4 flex w-full flex-col items-center gap-6 p-6 sm:w-[95%] md:w-[90%] lg:w-[85%] xl:w-240'>
+        <div className='flex flex-col items-center gap-2'>
+          <h1 className='text-3xl font-bold'>
+            {isChanging ? 'Change Your Clan' : 'Choose Your Clan'}
+          </h1>
+          <p className='text-center opacity-70'>
+            {isChanging
+              ? 'Your statistics will be reset when you join a new clan'
+              : 'Join a fraction to battle alongside your allies. Choose wisely — you can change after one week.'}
+          </p>
+        </div>
+
+        {isChanging && (
+          <div className='doodle-border w-full p-3 text-center text-sm'>
+             ! Changing your clan will reset all your battle statistics
+          </div>
+        )}
+
+        {error && <Message variant='error' message={error} />}
+
+        <div className='grid w-full grid-cols-1 gap-4 sm:grid-cols-3 items-start'>
+          {(Object.keys(clans) as ClanKey[]).map(key => (
+            <ClanCard
+              key={key}
+              clanKey={key}
+              isCurrent={currentClanKey === key}
+              onJoin={handleJoin}
+              onDetails={setDetailsClan}
+              disabled={actionLoading}
+            />
+          ))}
+        </div>
+
+        {isChanging && (
+          <Button variant='secondary' onClick={() => setIsChanging(false)} className='w-48'>
+            Cancel
+          </Button>
+        )}
+      </section>
+    );
+  }
+
+  const current = clans[currentClanKey];
+
+  return (
+    <section className='doodle-border mx-auto my-4 flex w-full flex-col items-center gap-6 p-6 sm:w-[95%] md:w-[90%] lg:w-[85%] xl:w-240'>
+      <h1 className='text-3xl font-bold'>Your Clan</h1>
+      <div className='doodle-border flex w-full flex-col items-center gap-4 p-6 sm:flex-row sm:gap-8'>
+        <img src={current.image} alt={current.name} className='h-32 w-32 object-contain' />
+        <div className='flex flex-col gap-1'>
+          <h2 className='text-2xl font-bold'>{current.name}</h2>
+          <p className='opacity-70 italic'>{current.tagline}</p>
+          <p className='text-sm opacity-50 mt-1'>{current.description}</p>
+
+        </div>
+      </div>
+
+      {error && <Message variant='error' message={error} />}
+
+      <div className='doodle-border flex w-full flex-col items-center gap-4 p-4'>
+        <h2 className='text-xl font-semibold'>Change Clan</h2>
+        <p className='text-center text-sm opacity-70'>
+          Changing your clan will reset all battle statistics
+        </p>
+        <Button onClick={() => setIsChanging(true)} variant='secondary' className='w-48'>
+          Change Clan
+        </Button>
+      </div>
+    </section>
+  );
 };
 
 export default Clans;

--- a/sea-of-code/src/pages/clans/clans.tsx
+++ b/sea-of-code/src/pages/clans/clans.tsx
@@ -10,6 +10,7 @@ import { db } from '../../firebase/config';
 import ClanCard from './components/ClanCard';
 import ClanDetailView from './components/ClanDetailView';
 import type { ClanKey, ClanStatsMap } from '../../types/clans.type';
+import './clans.css';
 
 const Clans = () => {
   const { user, userData, loading } = useAuth();

--- a/sea-of-code/src/pages/clans/clans.tsx
+++ b/sea-of-code/src/pages/clans/clans.tsx
@@ -3,7 +3,6 @@ import { collection, onSnapshot } from 'firebase/firestore';
 import { useAuth } from '../../firebase/useAuth';
 import { joinClan } from '../../api/users';
 import { clans } from '../../constants/images';
-import Button from '../../components/ui/Button';
 import Loading from '../../components/ui/loading';
 import Message from '../../components/ui/Message';
 import { db } from '../../firebase/config';
@@ -14,11 +13,9 @@ import './clans.css';
 
 const Clans = () => {
   const { user, userData, loading } = useAuth();
-  const [isChanging, setIsChanging] = useState(false);
   const [actionLoading, setActionLoading] = useState(false);
   const [error, setError] = useState('');
   const [detailsClan, setDetailsClan] = useState<ClanKey | null>(null);
-  const [stayOnGrid, setStayOnGrid] = useState(false);
   const [clanStats, setClanStats] = useState<ClanStatsMap>({});
 
   useEffect(() => {
@@ -60,18 +57,14 @@ const Clans = () => {
     setActionLoading(true);
     setError('');
     try {
-      const isChange = !!currentClanKey && isChanging;
+      const isChange = !!currentClanKey;
       await joinClan(user.uid, clanKey, isChange);
-      setIsChanging(false);
-      setStayOnGrid(true);
     } catch {
       setError('Failed to join clan. Please try again.');
     } finally {
       setActionLoading(false);
     }
   };
-
-  const showSelection = !currentClanKey || isChanging || stayOnGrid;
 
   if (detailsClan) {
     return (
@@ -83,27 +76,20 @@ const Clans = () => {
     );
   }
 
-  if (showSelection) {
-    return (
+  return (
       <section className='doodle doodle-border mx-auto my-4 flex w-full flex-col items-center gap-6 p-6 sm:w-[95%] md:w-[90%] lg:w-[85%] xl:w-240'>
         <div className='flex flex-col items-center gap-2'>
-          <h1 className='text-3xl font-bold'>
-            {isChanging ? 'Change Your Clan' : 'Choose Your Clan'}
-          </h1>
+          <h1 className='text-3xl font-bold'>Choose Your Clan</h1>
           <p className='text-center opacity-70'>
-            {isChanging
-              ? 'Your statistics will be reset when you join a new clan'
-              : 'Join a fraction to battle alongside your allies. Choose wisely — you can change after one week.'}
+            Join a fraction to battle alongside your allies. Choose wisely — you can change after one week.
           </p>
         </div>
 
-        {isChanging && (
-          <div className='doodle-border w-full p-3 text-center text-sm'>
-             ! Changing your clan will reset all your battle statistics
-          </div>
-        )}
-
         {error && <Message variant='error' message={error} />}
+
+        <div className='doodle-border w-full p-3 text-center text-sm'>
+          ! Changing your clan will reset all your battle statistics
+        </div>
 
         <div className='grid w-full grid-cols-1 gap-4 sm:grid-cols-3 items-start'>
           {(Object.keys(clans) as ClanKey[]).map(key => (
@@ -119,57 +105,8 @@ const Clans = () => {
           ))}
         </div>
 
-        {isChanging && (
-          <Button variant='secondary' onClick={() => setIsChanging(false)} className='w-48'>
-            Cancel
-          </Button>
-        )}
       </section>
     );
-  }
-
-  const current = clans[currentClanKey];
-
-  return (
-    <section className='doodle doodle-border mx-auto my-4 flex w-full flex-col items-center gap-6 p-6 sm:w-[95%] md:w-[90%] lg:w-[85%] xl:w-240'>
-      <h1 className='text-3xl font-bold'>Your Clan</h1>
-      <div className='doodle-border flex w-full flex-col items-center gap-4 p-6 sm:flex-row sm:gap-8'>
-        <img src={current.image} alt={current.name} className='h-32 w-32 object-contain' />
-        <div className='flex flex-col gap-1'>
-          <h2 className='text-2xl font-bold'>{current.name}</h2>
-          <p className='opacity-70 italic'>{current.tagline}</p>
-          <p className='text-sm opacity-50 mt-1'>{current.description}</p>
-        </div>
-      </div>
-
-      <div className='doodle-border grid w-full grid-cols-3 gap-4 p-4 text-center'>
-        <div>
-          <div className='text-2xl font-bold'>{clanStats[currentClanKey]?.members ?? '—'}</div>
-          <div className='text-xs opacity-60'>members</div>
-        </div>
-        <div>
-          <div className='text-2xl font-bold'>{clanStats[currentClanKey]?.victories ?? '—'}</div>
-          <div className='text-xs opacity-60'>total victories</div>
-        </div>
-        <div>
-          <div className='text-2xl font-bold'>{clanStats[currentClanKey]?.battles ?? '—'}</div>
-          <div className='text-xs opacity-60'>total battles</div>
-        </div>
-      </div>
-
-      {error && <Message variant='error' message={error} />}
-
-      <div className='doodle-border flex w-full flex-col items-center gap-4 p-4'>
-        <h2 className='text-xl font-semibold'>Change Clan</h2>
-        <p className='text-center text-sm opacity-70'>
-          Changing your clan will reset all battle statistics
-        </p>
-        <Button onClick={() => setIsChanging(true)} variant='secondary' className='w-48'>
-          Change Clan
-        </Button>
-      </div>
-    </section>
-  );
 };
 
 export default Clans;

--- a/sea-of-code/src/pages/clans/clans.tsx
+++ b/sea-of-code/src/pages/clans/clans.tsx
@@ -9,6 +9,7 @@ import { db } from '../../firebase/config';
 import ClanCard from './components/ClanCard';
 import ClanDetailView from './components/ClanDetailView';
 import ChangeClanModal from './components/ChangeClanModal';
+import JoinSuccessModal from './components/JoinSuccessModal';
 import type { ClanKey, ClanStatsMap } from '../../types/clans.type';
 import './clans.css';
 
@@ -18,6 +19,8 @@ const Clans = () => {
   const [error, setError] = useState('');
   const [confirmClan, setConfirmClan] = useState<ClanKey | null>(null);
   const [detailsClan, setDetailsClan] = useState<ClanKey | null>(null);
+  const [joinedClan, setJoinedClan] = useState<ClanKey | null>(null);
+  const [highlightedClan, setHighlightedClan] = useState<ClanKey | null>(null);
   const [clanStats, setClanStats] = useState<ClanStatsMap>({});
 
   useEffect(() => {
@@ -75,6 +78,7 @@ const Clans = () => {
     setError('');
     try {
       await joinClan(user.uid, clanKey, isChange);
+      setJoinedClan(clanKey);
     } catch {
       setError('Failed to join clan. Please try again.');
     } finally {
@@ -101,6 +105,16 @@ const Clans = () => {
           disabled={actionLoading}
         />
       )}
+      {joinedClan && (
+        <JoinSuccessModal
+          clanKey={joinedClan}
+          onClose={() => {
+            setHighlightedClan(joinedClan);
+            setJoinedClan(null);
+            setTimeout(() => setHighlightedClan(null), 600);
+          }}
+        />
+      )}
       <section className='doodle doodle-border mx-auto my-4 flex w-full flex-col items-center gap-6 p-6 sm:w-[95%] md:w-[90%] lg:w-[85%] xl:w-240'>
         <div className='flex flex-col items-center gap-2'>
           <h1 className='text-3xl font-bold'>Choose Your Clan</h1>
@@ -121,6 +135,7 @@ const Clans = () => {
               key={key}
               clanKey={key}
               isCurrent={currentClanKey === key}
+              highlight={highlightedClan === key}
               onJoin={handleJoin}
               onDetails={setDetailsClan}
               disabled={actionLoading}

--- a/sea-of-code/src/pages/clans/clans.tsx
+++ b/sea-of-code/src/pages/clans/clans.tsx
@@ -10,6 +10,7 @@ import ClanCard from './components/ClanCard';
 import ClanDetailView from './components/ClanDetailView';
 import ChangeClanModal from './components/ChangeClanModal';
 import JoinSuccessModal from './components/JoinSuccessModal';
+import ClanRankingBoard from './components/ClanRankingBoard';
 import type { ClanKey, ClanStatsMap } from '../../types/clans.type';
 import './clans.css';
 
@@ -32,11 +33,11 @@ const Clans = () => {
         if (!clan || !(clan in clans)) return;
         if (!stats[clan]) stats[clan] = { members: 0, victories: 0, battles: 0, topPlayers: [] };
         stats[clan]!.members += 1;
-        stats[clan]!.victories += data.stats?.victories ?? 0;
-        stats[clan]!.battles += data.stats?.battles ?? 0;
+        stats[clan]!.victories += data.stats?.clanStats?.victories ?? 0;
+        stats[clan]!.battles += data.stats?.clanStats?.battles ?? 0;
         stats[clan]!.topPlayers.push({
           displayName: data.displayName ?? 'Unknown',
-          victories: data.stats?.victories ?? 0,
+          victories: data.stats?.clanStats?.victories ?? 0,
           rank: data.stats?.rank ?? 'unga',
         });
       });
@@ -143,6 +144,8 @@ const Clans = () => {
             />
           ))}
         </div>
+
+        <ClanRankingBoard clanStats={clanStats} />
 
       </section>
     </>

--- a/sea-of-code/src/pages/clans/clans.tsx
+++ b/sea-of-code/src/pages/clans/clans.tsx
@@ -9,7 +9,7 @@ import Message from '../../components/ui/Message';
 import { db } from '../../firebase/config';
 import ClanCard from './components/ClanCard';
 import ClanDetailView from './components/ClanDetailView';
-import type { ClanKey, ClanStatsMap } from './types';
+import type { ClanKey, ClanStatsMap } from '../../types/clans.type';
 
 const Clans = () => {
   const { user, userData, loading } = useAuth();
@@ -27,10 +27,22 @@ const Clans = () => {
         const data = doc.data();
         const clan = data.stats?.clan as ClanKey | null;
         if (!clan || !(clan in clans)) return;
-        if (!stats[clan]) stats[clan] = { members: 0, victories: 0, battles: 0 };
+        if (!stats[clan]) stats[clan] = { members: 0, victories: 0, battles: 0, topPlayers: [] };
         stats[clan]!.members += 1;
         stats[clan]!.victories += data.stats?.victories ?? 0;
         stats[clan]!.battles += data.stats?.battles ?? 0;
+        stats[clan]!.topPlayers.push({
+          displayName: data.displayName ?? 'Unknown',
+          victories: data.stats?.victories ?? 0,
+          rank: data.stats?.rank ?? 'unga',
+        });
+      });
+      Object.values(stats).forEach(clanStat => {
+        if (clanStat) {
+          clanStat.topPlayers = clanStat.topPlayers
+            .sort((a, b) => b.victories - a.victories)
+            .slice(0, 5);
+        }
       });
       setClanStats(stats);
     });

--- a/sea-of-code/src/pages/clans/clans.tsx
+++ b/sea-of-code/src/pages/clans/clans.tsx
@@ -1,85 +1,15 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { collection, onSnapshot } from 'firebase/firestore';
 import { useAuth } from '../../firebase/useAuth';
 import { joinClan } from '../../api/users';
 import { clans } from '../../constants/images';
 import Button from '../../components/ui/Button';
 import Loading from '../../components/ui/loading';
 import Message from '../../components/ui/Message';
-
-type ClanKey = keyof typeof clans;
-
-const ClanCard = ({
-  clanKey,
-  isCurrent,
-  onJoin,
-  onDetails,
-  disabled,
-}: {
-  clanKey: ClanKey;
-  isCurrent: boolean;
-  onJoin: (key: ClanKey) => void;
-  onDetails: (key: ClanKey) => void;
-  disabled: boolean;
-}) => {
-  const clan = clans[clanKey];
-  return (
-    <div
-      className={`doodle-border flex flex-col items-center gap-3 p-4 transition-all ${isCurrent ? 'bg-indigo-100 dark:bg-indigo-900/30 scale-[1.02] shadow-lg' : 'opacity-80 hover:opacity-100'}`}
-    >
-      <img
-        src={clan.image}
-        alt={clan.name}
-        className={`h-24 w-24 object-contain transition-all ${isCurrent ? 'scale-110' : ''}`}
-      />
-      <h2 className='text-center text-lg font-semibold'>{clan.name}</h2>
-      {isCurrent && (
-        <span className='text-xs font-semibold text-indigo-500 uppercase tracking-widest'>
-          Your clan
-        </span>
-      )}
-      <p className='text-center text-sm opacity-70'>{clan.tagline}</p>
-
-      <div className='mt-auto flex w-full flex-col gap-2'>
-        <Button variant='secondary' onClick={() => onDetails(clanKey)} className='w-full'>
-          About
-        </Button>
-        {!isCurrent && (
-          <Button onClick={() => onJoin(clanKey)} disabled={disabled} variant='primary' className='w-full'>
-            Join
-          </Button>
-        )}
-      </div>
-    </div>
-  );
-};
-
-const ClanDetailView = ({
-  clanKey,
-  onBack,
-}: {
-  clanKey: ClanKey;
-  onBack: () => void;
-}) => {
-  const clan = clans[clanKey];
-  return (
-    <section className='doodle-border mx-auto my-4 flex w-full flex-col items-center gap-6 p-6 sm:w-[95%] md:w-[90%] lg:w-[85%] xl:w-240'>
-      <div className='flex w-full'>
-        <Button variant='secondary' onClick={onBack} className='w-28'>
-          ← Back
-        </Button>
-      </div>
-
-      <div className='doodle-border flex w-full flex-col items-center gap-4 p-6 sm:flex-row sm:gap-8'>
-        <img src={clan.image} alt={clan.name} className='h-32 w-32 object-contain' />
-        <div className='flex flex-col gap-2'>
-          <h2 className='text-2xl font-bold'>{clan.name}</h2>
-          <p className='opacity-70 italic'>{clan.tagline}</p>
-          <p className='text-sm opacity-50 leading-relaxed'>{clan.description}</p>
-        </div>
-      </div>
-    </section>
-  );
-};
+import { db } from '../../firebase/config';
+import ClanCard from './components/ClanCard';
+import ClanDetailView from './components/ClanDetailView';
+import type { ClanKey, ClanStatsMap } from './types';
 
 const Clans = () => {
   const { user, userData, loading } = useAuth();
@@ -88,6 +18,24 @@ const Clans = () => {
   const [error, setError] = useState('');
   const [detailsClan, setDetailsClan] = useState<ClanKey | null>(null);
   const [stayOnGrid, setStayOnGrid] = useState(false);
+  const [clanStats, setClanStats] = useState<ClanStatsMap>({});
+
+  useEffect(() => {
+    const unsubscribe = onSnapshot(collection(db, 'users'), snapshot => {
+      const stats: ClanStatsMap = {};
+      snapshot.forEach(doc => {
+        const data = doc.data();
+        const clan = data.stats?.clan as ClanKey | null;
+        if (!clan || !(clan in clans)) return;
+        if (!stats[clan]) stats[clan] = { members: 0, victories: 0, battles: 0 };
+        stats[clan]!.members += 1;
+        stats[clan]!.victories += data.stats?.victories ?? 0;
+        stats[clan]!.battles += data.stats?.battles ?? 0;
+      });
+      setClanStats(stats);
+    });
+    return unsubscribe;
+  }, []);
 
   if (loading) return <Loading />;
   if (!user || !userData) return <Message variant='error' message='Please log in' />;
@@ -113,12 +61,18 @@ const Clans = () => {
   const showSelection = !currentClanKey || isChanging || stayOnGrid;
 
   if (detailsClan) {
-    return <ClanDetailView clanKey={detailsClan} onBack={() => setDetailsClan(null)} />;
+    return (
+      <ClanDetailView
+        clanKey={detailsClan}
+        onBack={() => setDetailsClan(null)}
+        stats={clanStats[detailsClan]}
+      />
+    );
   }
 
   if (showSelection) {
     return (
-      <section className='doodle-border mx-auto my-4 flex w-full flex-col items-center gap-6 p-6 sm:w-[95%] md:w-[90%] lg:w-[85%] xl:w-240'>
+      <section className='doodle doodle-border mx-auto my-4 flex w-full flex-col items-center gap-6 p-6 sm:w-[95%] md:w-[90%] lg:w-[85%] xl:w-240'>
         <div className='flex flex-col items-center gap-2'>
           <h1 className='text-3xl font-bold'>
             {isChanging ? 'Change Your Clan' : 'Choose Your Clan'}
@@ -147,6 +101,7 @@ const Clans = () => {
               onJoin={handleJoin}
               onDetails={setDetailsClan}
               disabled={actionLoading}
+              stats={clanStats[key]}
             />
           ))}
         </div>
@@ -163,7 +118,7 @@ const Clans = () => {
   const current = clans[currentClanKey];
 
   return (
-    <section className='doodle-border mx-auto my-4 flex w-full flex-col items-center gap-6 p-6 sm:w-[95%] md:w-[90%] lg:w-[85%] xl:w-240'>
+    <section className='doodle doodle-border mx-auto my-4 flex w-full flex-col items-center gap-6 p-6 sm:w-[95%] md:w-[90%] lg:w-[85%] xl:w-240'>
       <h1 className='text-3xl font-bold'>Your Clan</h1>
       <div className='doodle-border flex w-full flex-col items-center gap-4 p-6 sm:flex-row sm:gap-8'>
         <img src={current.image} alt={current.name} className='h-32 w-32 object-contain' />
@@ -171,7 +126,21 @@ const Clans = () => {
           <h2 className='text-2xl font-bold'>{current.name}</h2>
           <p className='opacity-70 italic'>{current.tagline}</p>
           <p className='text-sm opacity-50 mt-1'>{current.description}</p>
+        </div>
+      </div>
 
+      <div className='doodle-border grid w-full grid-cols-3 gap-4 p-4 text-center'>
+        <div>
+          <div className='text-2xl font-bold'>{clanStats[currentClanKey]?.members ?? '—'}</div>
+          <div className='text-xs opacity-60'>members</div>
+        </div>
+        <div>
+          <div className='text-2xl font-bold'>{clanStats[currentClanKey]?.victories ?? '—'}</div>
+          <div className='text-xs opacity-60'>total victories</div>
+        </div>
+        <div>
+          <div className='text-2xl font-bold'>{clanStats[currentClanKey]?.battles ?? '—'}</div>
+          <div className='text-xs opacity-60'>total battles</div>
         </div>
       </div>
 

--- a/sea-of-code/src/pages/clans/components/ChangeClanModal.tsx
+++ b/sea-of-code/src/pages/clans/components/ChangeClanModal.tsx
@@ -1,0 +1,38 @@
+import Button from '../../../components/ui/Button';
+
+interface ChangeClanModalProps {
+  onConfirm: () => void;
+  onCancel: () => void;
+  disabled?: boolean;
+}
+
+const ChangeClanModal = ({ onConfirm, onCancel, disabled }: ChangeClanModalProps) => {
+  return (
+    <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50'>
+      <div
+        className='doodle doodle-border flex w-full max-w-sm flex-col gap-4 p-6 mx-4'
+        style={{
+          background: `linear-gradient(var(--color-bg-secondary), transparent 2px), linear-gradient(90deg, var(--color-bg-secondary), transparent 2px)`,
+          backgroundSize: '20px 20px',
+          backgroundPosition: 'center center',
+          backgroundColor: 'var(--color-bg-primary)',
+        }}
+      >
+        <h2 className='text-xl font-bold'>Change Clan?</h2>
+        <p className='text-sm opacity-80'>
+          Are you sure you want to change your clan? All your battle statistics will be reset.
+        </p>
+        <div className='flex gap-3'>
+          <Button variant='primary' onClick={onConfirm} disabled={disabled}>
+            Confirm
+          </Button>
+          <Button variant='secondary' onClick={onCancel} disabled={disabled}>
+            Cancel
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChangeClanModal;

--- a/sea-of-code/src/pages/clans/components/ChangeClanModal.tsx
+++ b/sea-of-code/src/pages/clans/components/ChangeClanModal.tsx
@@ -1,4 +1,5 @@
 import Button from '../../../components/ui/Button';
+import ClanModal from './ClanModal';
 
 interface ChangeClanModalProps {
   onConfirm: () => void;
@@ -8,30 +9,20 @@ interface ChangeClanModalProps {
 
 const ChangeClanModal = ({ onConfirm, onCancel, disabled }: ChangeClanModalProps) => {
   return (
-    <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50'>
-      <div
-        className='doodle doodle-border flex w-full max-w-sm flex-col gap-4 p-6 mx-4'
-        style={{
-          background: `linear-gradient(var(--color-bg-secondary), transparent 2px), linear-gradient(90deg, var(--color-bg-secondary), transparent 2px)`,
-          backgroundSize: '20px 20px',
-          backgroundPosition: 'center center',
-          backgroundColor: 'var(--color-bg-primary)',
-        }}
-      >
-        <h2 className='text-xl font-bold'>Change Clan?</h2>
-        <p className='text-sm opacity-80'>
-          Are you sure you want to change your clan? All your battle statistics will be reset.
-        </p>
-        <div className='flex gap-3'>
-          <Button variant='primary' onClick={onConfirm} disabled={disabled}>
-            Confirm
-          </Button>
-          <Button variant='secondary' onClick={onCancel} disabled={disabled}>
-            Cancel
-          </Button>
-        </div>
+    <ClanModal>
+      <h2 className='text-xl font-bold'>Change Clan?</h2>
+      <p className='text-sm opacity-80'>
+        Are you sure you want to change your clan? All your battle statistics will be reset.
+      </p>
+      <div className='flex gap-3'>
+        <Button variant='primary' onClick={onConfirm} disabled={disabled}>
+          Confirm
+        </Button>
+        <Button variant='secondary' onClick={onCancel} disabled={disabled}>
+          Cancel
+        </Button>
       </div>
-    </div>
+    </ClanModal>
   );
 };
 

--- a/sea-of-code/src/pages/clans/components/ClanCard.tsx
+++ b/sea-of-code/src/pages/clans/components/ClanCard.tsx
@@ -15,16 +15,24 @@ const ClanCard = ({ clanKey, isCurrent, onJoin, onDetails, disabled, stats }: Cl
   const clan = clans[clanKey];
   return (
     <div
-      className={`doodle doodle-border flex flex-col items-center gap-3 p-4 transition-all ${isCurrent ? 'bg-indigo-100 dark:bg-indigo-900/30 scale-[1.02] shadow-lg' : 'opacity-80 hover:opacity-100'}`}
+      className={`clan-card doodle doodle-border flex flex-col items-center gap-3 p-4 ${isCurrent ? 'clan-card--active' : 'opacity-80 hover:opacity-100'}`}
+      style={{
+        '--clan-color': clan.color,
+        backgroundColor: isCurrent ? clan.colorMuted : undefined,
+      } as React.CSSProperties}
     >
       <img
         src={clan.image}
         alt={clan.name}
         className={`h-24 w-24 object-contain transition-all ${isCurrent ? 'scale-110' : ''}`}
+        style={isCurrent ? { filter: `drop-shadow(0 0 10px ${clan.color}90)` } : undefined}
       />
       <h2 className='text-center text-lg font-semibold'>{clan.name}</h2>
       {isCurrent && (
-        <span className='text-xs font-semibold text-indigo-500 uppercase tracking-widest'>
+        <span
+          className='text-xs font-semibold uppercase tracking-widest'
+          style={{ color: clan.color }}
+        >
           Your clan
         </span>
       )}
@@ -45,11 +53,22 @@ const ClanCard = ({ clanKey, isCurrent, onJoin, onDetails, disabled, stats }: Cl
       </div>
 
       <div className='mt-auto flex w-full flex-col gap-2'>
-        <Button variant='secondary' onClick={() => onDetails(clanKey)} className='w-full'>
+        <Button
+          variant='secondary'
+          onClick={() => onDetails(clanKey)}
+          className='w-full'
+          style={{ backgroundColor: clan.colorMuted, color: clan.color }}
+        >
           About
         </Button>
         {!isCurrent && (
-          <Button onClick={() => onJoin(clanKey)} disabled={disabled} variant='primary' className='w-full'>
+          <Button
+            onClick={() => onJoin(clanKey)}
+            disabled={disabled}
+            variant='primary'
+            className='w-full'
+            style={{ backgroundColor: clan.color, color: '#fff' }}
+          >
             Join
           </Button>
         )}

--- a/sea-of-code/src/pages/clans/components/ClanCard.tsx
+++ b/sea-of-code/src/pages/clans/components/ClanCard.tsx
@@ -5,17 +5,18 @@ import type { ClanKey, ClanStats } from '../../../types/clans.type';
 interface ClanCardProps {
   clanKey: ClanKey;
   isCurrent: boolean;
+  highlight?: boolean;
   onJoin: (key: ClanKey) => void;
   onDetails: (key: ClanKey) => void;
   disabled: boolean;
   stats?: ClanStats;
 }
 
-const ClanCard = ({ clanKey, isCurrent, onJoin, onDetails, disabled, stats }: ClanCardProps) => {
+const ClanCard = ({ clanKey, isCurrent, highlight, onJoin, onDetails, disabled, stats }: ClanCardProps) => {
   const clan = clans[clanKey];
   return (
     <div
-      className={`clan-card doodle doodle-border flex flex-col items-center gap-3 p-4 ${isCurrent ? 'clan-card--active' : 'opacity-80 hover:opacity-100'}`}
+      className={`clan-card doodle doodle-border flex flex-col items-center gap-3 p-4 ${isCurrent ? 'clan-card--active' : 'opacity-80 hover:opacity-100'} ${highlight ? 'clan-card--just-joined' : ''}`}
       style={{
         '--clan-color': clan.color,
         backgroundColor: isCurrent ? clan.colorMuted : undefined,

--- a/sea-of-code/src/pages/clans/components/ClanCard.tsx
+++ b/sea-of-code/src/pages/clans/components/ClanCard.tsx
@@ -1,6 +1,6 @@
 import { clans } from '../../../constants/images';
 import Button from '../../../components/ui/Button';
-import type { ClanKey, ClanStats } from '../types';
+import type { ClanKey, ClanStats } from '../../../types/clans.type';
 
 interface ClanCardProps {
   clanKey: ClanKey;

--- a/sea-of-code/src/pages/clans/components/ClanCard.tsx
+++ b/sea-of-code/src/pages/clans/components/ClanCard.tsx
@@ -1,0 +1,61 @@
+import { clans } from '../../../constants/images';
+import Button from '../../../components/ui/Button';
+import type { ClanKey, ClanStats } from '../types';
+
+interface ClanCardProps {
+  clanKey: ClanKey;
+  isCurrent: boolean;
+  onJoin: (key: ClanKey) => void;
+  onDetails: (key: ClanKey) => void;
+  disabled: boolean;
+  stats?: ClanStats;
+}
+
+const ClanCard = ({ clanKey, isCurrent, onJoin, onDetails, disabled, stats }: ClanCardProps) => {
+  const clan = clans[clanKey];
+  return (
+    <div
+      className={`doodle doodle-border flex flex-col items-center gap-3 p-4 transition-all ${isCurrent ? 'bg-indigo-100 dark:bg-indigo-900/30 scale-[1.02] shadow-lg' : 'opacity-80 hover:opacity-100'}`}
+    >
+      <img
+        src={clan.image}
+        alt={clan.name}
+        className={`h-24 w-24 object-contain transition-all ${isCurrent ? 'scale-110' : ''}`}
+      />
+      <h2 className='text-center text-lg font-semibold'>{clan.name}</h2>
+      {isCurrent && (
+        <span className='text-xs font-semibold text-indigo-500 uppercase tracking-widest'>
+          Your clan
+        </span>
+      )}
+      <p className='text-center text-sm opacity-70'>{clan.tagline}</p>
+      <div className='flex w-full justify-around text-center text-xs opacity-60'>
+        <div>
+          <div className='font-semibold text-sm'>{stats?.members ?? '—'}</div>
+          <div>members</div>
+        </div>
+        <div>
+          <div className='font-semibold text-sm'>{stats?.victories ?? '—'}</div>
+          <div>victories</div>
+        </div>
+        <div>
+          <div className='font-semibold text-sm'>{stats?.battles ?? '—'}</div>
+          <div>battles</div>
+        </div>
+      </div>
+
+      <div className='mt-auto flex w-full flex-col gap-2'>
+        <Button variant='secondary' onClick={() => onDetails(clanKey)} className='w-full'>
+          About
+        </Button>
+        {!isCurrent && (
+          <Button onClick={() => onJoin(clanKey)} disabled={disabled} variant='primary' className='w-full'>
+            Join
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ClanCard;

--- a/sea-of-code/src/pages/clans/components/ClanDetailView.tsx
+++ b/sea-of-code/src/pages/clans/components/ClanDetailView.tsx
@@ -1,6 +1,7 @@
 import { clans } from '../../../constants/images';
 import Button from '../../../components/ui/Button';
-import type { ClanKey, ClanStats } from '../types';
+import ClanLeaderboard from './ClanLeaderboard';
+import type { ClanKey, ClanStats } from '../../../types/clans.type';
 
 interface ClanDetailViewProps {
   clanKey: ClanKey;
@@ -41,6 +42,8 @@ const ClanDetailView = ({ clanKey, onBack, stats }: ClanDetailViewProps) => {
           <div className='text-xs opacity-60'>total battles</div>
         </div>
       </div>
+
+      <ClanLeaderboard topPlayers={stats?.topPlayers ?? []} />
     </section>
   );
 };

--- a/sea-of-code/src/pages/clans/components/ClanDetailView.tsx
+++ b/sea-of-code/src/pages/clans/components/ClanDetailView.tsx
@@ -12,17 +12,37 @@ interface ClanDetailViewProps {
 const ClanDetailView = ({ clanKey, onBack, stats }: ClanDetailViewProps) => {
   const clan = clans[clanKey];
   return (
-    <section className='doodle doodle-border mx-auto my-4 flex w-full flex-col items-center gap-6 p-6 sm:w-[95%] md:w-[90%] lg:w-[85%] xl:w-240'>
+    <section
+      className='animate-fade-in-up doodle doodle-border mx-auto my-4 flex w-full flex-col items-center gap-6 p-6 sm:w-[95%] md:w-[90%] lg:w-[85%] xl:w-240'
+      style={{
+        backgroundColor: clan.colorMuted,
+        outline: `2px solid ${clan.color}30`,
+      }}
+    >
       <div className='flex w-full'>
-        <Button variant='secondary' onClick={onBack} className='w-28'>
+        <Button
+          variant='secondary'
+          onClick={onBack}
+          className='w-28'
+          style={{ backgroundColor: clan.colorMuted, color: clan.color, borderColor: clan.color }}
+        >
           ← Back
         </Button>
       </div>
 
-      <div className='doodle-border flex w-full flex-col items-center gap-4 p-6 sm:flex-row sm:gap-8'>
-        <img src={clan.image} alt={clan.name} className='h-32 w-32 object-contain' />
+      <div
+        className='doodle-border flex w-full flex-col items-center gap-4 p-6 sm:flex-row sm:gap-8'
+        style={{ borderLeft: `4px solid ${clan.color}` }}
+      >
+        <img
+          src={clan.image}
+          alt={clan.name}
+          className='h-32 w-32 object-contain'
+        />
         <div className='flex flex-col gap-2'>
-          <h2 className='text-2xl font-bold'>{clan.name}</h2>
+          <h2 className='text-2xl font-bold' style={{ color: clan.color }}>
+            {clan.name}
+          </h2>
           <p className='opacity-70 italic'>{clan.tagline}</p>
           <p className='text-sm opacity-50 leading-relaxed'>{clan.description}</p>
         </div>
@@ -30,20 +50,26 @@ const ClanDetailView = ({ clanKey, onBack, stats }: ClanDetailViewProps) => {
 
       <div className='doodle-border grid w-full grid-cols-3 gap-4 p-4 text-center'>
         <div>
-          <div className='text-2xl font-bold'>{stats?.members ?? '—'}</div>
+          <div className='text-2xl font-bold' style={{ color: clan.color }}>
+            {stats?.members ?? '—'}
+          </div>
           <div className='text-xs opacity-60'>members</div>
         </div>
         <div>
-          <div className='text-2xl font-bold'>{stats?.victories ?? '—'}</div>
+          <div className='text-2xl font-bold' style={{ color: clan.color }}>
+            {stats?.victories ?? '—'}
+          </div>
           <div className='text-xs opacity-60'>total victories</div>
         </div>
         <div>
-          <div className='text-2xl font-bold'>{stats?.battles ?? '—'}</div>
+          <div className='text-2xl font-bold' style={{ color: clan.color }}>
+            {stats?.battles ?? '—'}
+          </div>
           <div className='text-xs opacity-60'>total battles</div>
         </div>
       </div>
 
-      <ClanLeaderboard topPlayers={stats?.topPlayers ?? []} />
+      <ClanLeaderboard topPlayers={stats?.topPlayers ?? []} clanColor={clan.color} />
     </section>
   );
 };

--- a/sea-of-code/src/pages/clans/components/ClanDetailView.tsx
+++ b/sea-of-code/src/pages/clans/components/ClanDetailView.tsx
@@ -1,0 +1,48 @@
+import { clans } from '../../../constants/images';
+import Button from '../../../components/ui/Button';
+import type { ClanKey, ClanStats } from '../types';
+
+interface ClanDetailViewProps {
+  clanKey: ClanKey;
+  onBack: () => void;
+  stats?: ClanStats;
+}
+
+const ClanDetailView = ({ clanKey, onBack, stats }: ClanDetailViewProps) => {
+  const clan = clans[clanKey];
+  return (
+    <section className='doodle doodle-border mx-auto my-4 flex w-full flex-col items-center gap-6 p-6 sm:w-[95%] md:w-[90%] lg:w-[85%] xl:w-240'>
+      <div className='flex w-full'>
+        <Button variant='secondary' onClick={onBack} className='w-28'>
+          ← Back
+        </Button>
+      </div>
+
+      <div className='doodle-border flex w-full flex-col items-center gap-4 p-6 sm:flex-row sm:gap-8'>
+        <img src={clan.image} alt={clan.name} className='h-32 w-32 object-contain' />
+        <div className='flex flex-col gap-2'>
+          <h2 className='text-2xl font-bold'>{clan.name}</h2>
+          <p className='opacity-70 italic'>{clan.tagline}</p>
+          <p className='text-sm opacity-50 leading-relaxed'>{clan.description}</p>
+        </div>
+      </div>
+
+      <div className='doodle-border grid w-full grid-cols-3 gap-4 p-4 text-center'>
+        <div>
+          <div className='text-2xl font-bold'>{stats?.members ?? '—'}</div>
+          <div className='text-xs opacity-60'>members</div>
+        </div>
+        <div>
+          <div className='text-2xl font-bold'>{stats?.victories ?? '—'}</div>
+          <div className='text-xs opacity-60'>total victories</div>
+        </div>
+        <div>
+          <div className='text-2xl font-bold'>{stats?.battles ?? '—'}</div>
+          <div className='text-xs opacity-60'>total battles</div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ClanDetailView;

--- a/sea-of-code/src/pages/clans/components/ClanLeaderboard.tsx
+++ b/sea-of-code/src/pages/clans/components/ClanLeaderboard.tsx
@@ -3,9 +3,10 @@ import type { LeaderboardEntry } from '../../../types/clans.type';
 
 interface ClanLeaderboardProps {
   topPlayers: LeaderboardEntry[];
+  clanColor?: string;
 }
 
-const ClanLeaderboard = ({ topPlayers }: ClanLeaderboardProps) => {
+const ClanLeaderboard = ({ topPlayers, clanColor }: ClanLeaderboardProps) => {
   if (topPlayers.length === 0) {
     return (
       <div className='doodle-border w-full p-4 text-center text-sm opacity-60'>
@@ -20,12 +21,17 @@ const ClanLeaderboard = ({ topPlayers }: ClanLeaderboardProps) => {
       <ol className='flex flex-col gap-2'>
         {topPlayers.map((player, i) => {
           const rankLabel = ranks[player.rank as keyof typeof ranks]?.name ?? player.rank;
+          const isFirst = i === 0;
           return (
             <li
               key={i}
-              className={`flex items-center gap-3 rounded px-3 py-2 ${i === 0 ? 'bg-yellow-100 dark:bg-yellow-900/20 font-semibold' : 'opacity-80'}`}
+              className={`flex items-center gap-3 rounded px-3 py-2 ${isFirst ? 'font-semibold' : 'opacity-80'}`}
+              style={isFirst && clanColor ? { backgroundColor: `${clanColor}20` } : undefined}
             >
-              <span className='w-6 text-center text-sm font-bold opacity-60'>
+              <span
+                className='w-6 text-center text-sm font-bold'
+                style={isFirst && clanColor ? { color: clanColor } : { opacity: 0.6 }}
+              >
                 {i + 1}.
               </span>
               <span className='flex-1 truncate'>{player.displayName}</span>

--- a/sea-of-code/src/pages/clans/components/ClanLeaderboard.tsx
+++ b/sea-of-code/src/pages/clans/components/ClanLeaderboard.tsx
@@ -1,0 +1,42 @@
+import { ranks } from '../../../constants/images';
+import type { LeaderboardEntry } from '../../../types/clans.type';
+
+interface ClanLeaderboardProps {
+  topPlayers: LeaderboardEntry[];
+}
+
+const ClanLeaderboard = ({ topPlayers }: ClanLeaderboardProps) => {
+  if (topPlayers.length === 0) {
+    return (
+      <div className='doodle-border w-full p-4 text-center text-sm opacity-60'>
+        No members yet — be the first to join!
+      </div>
+    );
+  }
+
+  return (
+    <div className='doodle-border w-full p-4'>
+      <h3 className='mb-3 text-center text-lg font-bold'>Top Players</h3>
+      <ol className='flex flex-col gap-2'>
+        {topPlayers.map((player, i) => {
+          const rankLabel = ranks[player.rank as keyof typeof ranks]?.name ?? player.rank;
+          return (
+            <li
+              key={i}
+              className={`flex items-center gap-3 rounded px-3 py-2 ${i === 0 ? 'bg-yellow-100 dark:bg-yellow-900/20 font-semibold' : 'opacity-80'}`}
+            >
+              <span className='w-6 text-center text-sm font-bold opacity-60'>
+                {i + 1}.
+              </span>
+              <span className='flex-1 truncate'>{player.displayName}</span>
+              <span className='text-xs opacity-50 hidden sm:block'>{rankLabel}</span>
+              <span className='text-sm font-semibold'>{player.victories} victories</span>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+};
+
+export default ClanLeaderboard;

--- a/sea-of-code/src/pages/clans/components/ClanModal.tsx
+++ b/sea-of-code/src/pages/clans/components/ClanModal.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+
+interface ClanModalProps {
+  children: ReactNode;
+  className?: string;
+}
+
+const ClanModal = ({ children, className }: ClanModalProps) => (
+  <div className='modal-backdrop-animated fixed inset-0 z-50 flex items-center justify-center bg-black/50'>
+    <div
+      className={`doodle doodle-border flex w-full max-w-sm flex-col gap-4 p-6 mx-4${className ? ` ${className}` : ''}`}
+      style={{
+        background: `linear-gradient(var(--color-bg-secondary), transparent 2px), linear-gradient(90deg, var(--color-bg-secondary), transparent 2px)`,
+        backgroundSize: '20px 20px',
+        backgroundPosition: 'center center',
+        backgroundColor: 'var(--color-bg-primary)',
+      }}
+    >
+      {children}
+    </div>
+  </div>
+);
+
+export default ClanModal;

--- a/sea-of-code/src/pages/clans/components/ClanRankingBoard.tsx
+++ b/sea-of-code/src/pages/clans/components/ClanRankingBoard.tsx
@@ -1,0 +1,60 @@
+import { clans } from '../../../constants/images';
+import type { ClanKey, ClanRankingBoardProps } from '../../../types/clans.type';
+
+const ClanRankingBoard = ({ clanStats }: ClanRankingBoardProps) => {
+  const ranked = (Object.keys(clans) as ClanKey[])
+    .map(key => {
+      const stats = clanStats[key];
+      const victories = stats?.victories ?? 0;
+      const battles = stats?.battles ?? 0;
+      const winRate = battles > 0 ? Math.round((victories / battles) * 100) : 0;
+      return { key, victories, battles, members: stats?.members ?? 0, winRate };
+    })
+    .sort((a, b) => b.victories - a.victories || b.winRate - a.winRate);
+
+  return (
+    <div className='doodle-border w-full p-3 animate-fade-in-up'>
+      <h2 className='mb-3 text-center text-xl font-bold tracking-wide'>⚔️ Clan Rankings</h2>
+      <div className='flex flex-col gap-1'>
+        {ranked.map(({ key, victories, battles, members, winRate }, i) => {
+          const clan = clans[key];
+          const isFirst = i === 0;
+          return (
+            <div
+              key={key}
+              className='flex items-center gap-2 rounded px-2 py-2 transition-all min-w-0'
+              style={{
+                backgroundColor: isFirst ? `${clan.color}10` : undefined,
+              }}
+            >
+              <span className='w-6 shrink-0 text-center text-lg'>#{i + 1}</span>
+              <img
+                src={clan.image}
+                alt={clan.name}
+                className='h-8 w-8 shrink-0 object-contain'
+                style={isFirst ? { filter: `drop-shadow(0 0 6px ${clan.color}80)` } : { opacity: 0.8 }}
+              />
+              <div className='flex min-w-0 flex-1 flex-col'>
+                <span
+                  className={`truncate font-semibold ${isFirst ? 'text-sm' : 'text-xs'}`}
+                  style={{ color: clan.color }}
+                >
+                  {clan.name}
+                </span>
+                <span className='text-xs opacity-50'>{members} member{members !== 1 ? 's' : ''}</span>
+              </div>
+              <div className='flex shrink-0 flex-col items-end gap-0.5'>
+                <span className={`font-bold ${isFirst ? 'text-sm' : 'text-xs'}`} style={{ color: clan.color }}>
+                  {victories} <span className='font-normal opacity-60'>W</span>
+                </span>
+                <span className='text-xs opacity-40 whitespace-nowrap'>{winRate}% · {battles}b</span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ClanRankingBoard;

--- a/sea-of-code/src/pages/clans/components/ClanWarBar.tsx
+++ b/sea-of-code/src/pages/clans/components/ClanWarBar.tsx
@@ -1,0 +1,41 @@
+import { clans } from '../../../constants/images';
+import type { ClanKey, ClanStatsMap } from '../../../types/clans.type';
+
+interface ClanWarBarProps {
+  clanStats: ClanStatsMap;
+}
+
+const ClanWarBar = ({ clanStats }: ClanWarBarProps) => {
+  const keys = Object.keys(clans) as ClanKey[];
+  const totalVictories = keys.reduce((sum, key) => sum + (clanStats[key]?.victories ?? 0), 0);
+
+  if (totalVictories === 0) return null;
+
+  return (
+    <div className='w-full flex flex-col gap-1'>
+      <p className='text-xs opacity-50 text-center uppercase tracking-widest'>War standings</p>
+      <div className='flex w-full h-4 overflow-hidden rounded-sm doodle-border'>
+        {keys.map(key => {
+          const victories = clanStats[key]?.victories ?? 0;
+          const pct = (victories / totalVictories) * 100;
+          return (
+            <div
+              key={key}
+              title={`${clans[key].name}: ${victories} victories`}
+              style={{ width: `${pct}%`, backgroundColor: clans[key].color, transition: 'width 0.5s ease' }}
+            />
+          );
+        })}
+      </div>
+      <div className='flex justify-between text-xs opacity-60 px-0.5'>
+        {keys.map(key => (
+          <span key={key} style={{ color: clans[key].color }}>
+            {clans[key].name.split(' ').pop()} {clanStats[key]?.victories ?? 0}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ClanWarBar;

--- a/sea-of-code/src/pages/clans/components/JoinSuccessModal.tsx
+++ b/sea-of-code/src/pages/clans/components/JoinSuccessModal.tsx
@@ -1,0 +1,33 @@
+import Button from '../../../components/ui/Button';
+import ClanModal from './ClanModal';
+import { clans } from '../../../constants/images';
+import type { ClanKey } from '../../../types/clans.type';
+
+interface JoinSuccessModalProps {
+  clanKey: ClanKey;
+  onClose: () => void;
+}
+
+const JoinSuccessModal = ({ clanKey, onClose }: JoinSuccessModalProps) => {
+  const clan = clans[clanKey];
+
+  return (
+    <ClanModal className='modal-bounce-in'>
+      <div className='flex flex-col items-center gap-3 text-center'>
+        <img src={clan.image} alt={clan.name} className='modal-img-pop h-20 w-20 object-contain' />
+        <div className='modal-text-in flex flex-col items-center gap-3'>
+          <h2 className='text-xl font-bold'>Welcome to {clan.name}!</h2>
+          <p className='text-sm opacity-80'>{clan.tagline}</p>
+          <p className='text-sm opacity-70'>
+            You have successfully joined the clan. Battle alongside your allies and lead them to victory!
+          </p>
+          <Button variant='primary' onClick={onClose} className='mt-2'>
+            Let's Go!
+          </Button>
+        </div>
+      </div>
+    </ClanModal>
+  );
+};
+
+export default JoinSuccessModal;

--- a/sea-of-code/src/pages/clans/types.ts
+++ b/sea-of-code/src/pages/clans/types.ts
@@ -1,0 +1,11 @@
+import type { clans } from '../../constants/images';
+
+export type ClanKey = keyof typeof clans;
+
+export type ClanStats = {
+  members: number;
+  victories: number;
+  battles: number;
+};
+
+export type ClanStatsMap = Partial<Record<ClanKey, ClanStats>>;

--- a/sea-of-code/src/types/clans.type.ts
+++ b/sea-of-code/src/types/clans.type.ts
@@ -1,5 +1,9 @@
 import type { clans } from '../constants/images';
 
+export type ClanRankingBoardProps = {
+  clanStats: ClanStatsMap;
+};
+
 export type ClanKey = keyof typeof clans;
 
 export type LeaderboardEntry = {

--- a/sea-of-code/src/types/clans.type.ts
+++ b/sea-of-code/src/types/clans.type.ts
@@ -1,11 +1,18 @@
-import type { clans } from '../../constants/images';
+import type { clans } from '../constants/images';
 
 export type ClanKey = keyof typeof clans;
+
+export type LeaderboardEntry = {
+  displayName: string;
+  victories: number;
+  rank: string;
+};
 
 export type ClanStats = {
   members: number;
   victories: number;
   battles: number;
+  topPlayers: LeaderboardEntry[];
 };
 
 export type ClanStatsMap = Partial<Record<ClanKey, ClanStats>>;

--- a/sea-of-code/src/types/types.ts
+++ b/sea-of-code/src/types/types.ts
@@ -13,6 +13,12 @@ export type FirestoreUser = {
   stats: UserStats;
 };
 
+export type ClanStats = {
+  victories: number;
+  defeats: number;
+  battles: number;
+};
+
 export type UserStats = {
   rank: string;
   victories: number;
@@ -28,6 +34,7 @@ export type UserStats = {
   streak: number;
   lastLoginDate: Timestamp | null;
   clanJoinedAt: Timestamp | null;
+  clanStats: ClanStats;
 };
 
 export type FirestoreUserCreate = {
@@ -50,6 +57,11 @@ export type FirestoreUserCreate = {
     streak: number;
     lastLoginDate: FieldValue;
     clanJoinedAt: FieldValue | null;
+    clanStats: {
+      victories: number;
+      defeats: number;
+      battles: number;
+    };
   };
 };
 

--- a/sea-of-code/src/types/types.ts
+++ b/sea-of-code/src/types/types.ts
@@ -27,6 +27,7 @@ export type UserStats = {
   clan: string | null;
   streak: number;
   lastLoginDate: Timestamp | null;
+  clanJoinedAt: Timestamp | null;
 };
 
 export type FirestoreUserCreate = {
@@ -48,6 +49,7 @@ export type FirestoreUserCreate = {
     clan: string | null;
     streak: number;
     lastLoginDate: FieldValue;
+    clanJoinedAt: FieldValue | null;
   };
 };
 


### PR DESCRIPTION
## Clan page ui and functionality

This pull request introduces a comprehensive "Clans" feature, including clan membership management, statistics, leaderboards, and detailed clan information. The most important changes are grouped below:

**New Features and Functionality**

* Added support for joining and changing clans, including resetting battle statistics when switching clans.
* Implemented the main **Clans** page with the ability to view clan stats, top players, and detailed clan information.
* Added `ClanCard`, `ClanDetailView`, and `ClanLeaderboard` components.

**Backend and Data Model Enhancements**

* Introduced the `joinClan` function for updating clan membership.
* Added new TypeScript types for clans, clan statistics, and leaderboards to support the 

**Visual and UI Improvements**

* Expanded clan definitions with images, descriptions, taglines, and color themes.
* Added CSS animations and visual effects for clan cards and transitions.
* Improved loading states and error handling across the Clans feature.

**[issue](https://github.com/Auto-Team-9/sea-battle/issues/8)**

<img width="997" height="910" alt="2026-03-31_00-58-26" src="https://github.com/user-attachments/assets/85dff44f-fe59-4315-8693-d85a8a9ec265" />
<img width="990" height="904" alt="2026-03-31_00-58-37" src="https://github.com/user-attachments/assets/6a4fdf55-8059-416f-ab77-b671fefd5d03" />
<img width="979" height="897" alt="2026-03-31_00-58-48" src="https://github.com/user-attachments/assets/39d27509-57a4-4df2-881d-c0a09c3c7c12" />
